### PR TITLE
fix: Prevent multiple print redefinitions

### DIFF
--- a/util/misc.py
+++ b/util/misc.py
@@ -10,6 +10,7 @@
 # --------------------------------------------------------
 
 import builtins
+from builtins import print as print_builtin
 import datetime
 import os
 import time
@@ -171,7 +172,7 @@ def setup_for_distributed(is_master):
     """
     This function disables printing when not in master process
     """
-    builtin_print = builtins.print
+    builtin_print = print_builtin
 
     def print(*args, **kwargs):
         force = kwargs.pop('force', False)


### PR DESCRIPTION
Calling `util.misc.setup_for_distributed` multiple times (which happens in my use-case as I re-use processes for multiple training runs) causes the print statements to get longer because multiple identical time stamps are printed in front of every statement. This fixes that by referencing the unmodified `builtins.print` for every modification.
