### PR TITLE
Fix deprecated np.float

### DIFF
--- a/util/pos_embed.py
+++ b/util/pos_embed.py
@@ -8,8 +8,8 @@
 # --------------------------------------------------------
 
 import numpy as np
-
 import torch
+
 
 # --------------------------------------------------------
 # 2D sine-cosine position embedding
@@ -53,7 +53,7 @@ def get_1d_sincos_pos_embed_from_grid(embed_dim, pos):
     out: (M, D)
     """
     assert embed_dim % 2 == 0
-    omega = np.arange(embed_dim // 2, dtype=np.float)
+    omega = np.arange(embed_dim // 2, dtype=np.float32)
     omega /= embed_dim / 2.
     omega = 1. / 10000**omega  # (D/2,)
 


### PR DESCRIPTION
This minor PR fixes the deprecated use of `np.float`, which was deprecated in NumPy 1.20.

It changes `np.float` in `get_1d_sincos_pos_embed_from_grid` to `np.float32` (in line with the usage in `get_2d_sincos_pos_embed` in the same file).

Without this fix (or switching to an old NumPy) version, building the model (e.g., to load weights) yields the following error:

```pyerror
AttributeError: module 'numpy' has no attribute 'float'.
`np.float` was a deprecated alias for the builtin `float`. To avoid this error in existing code, use `float` by itself. Doing this will not modify any behavior and is safe. If you specifically wanted the numpy scalar type, use `np.float64` here.
The aliases was originally deprecated in NumPy 1.20; for more details and guidance see the original release note at:
    https://numpy.org/devdocs/release/1.20.0-notes.html#deprecations
```